### PR TITLE
Delay IRC message sending to prevent flooding

### DIFF
--- a/util/irc_bot.py
+++ b/util/irc_bot.py
@@ -52,6 +52,7 @@ class IRCBot(object):
   def main_loop(self, connection):
     for message in self.messages:
       connection.notice(self.channel, str(message))
+      time.sleep(1) # Pause for a second to prevent flooding.
     connection.quit("Using irc.client.py")
 
   def on_disconnect(self, connection, event):

--- a/util/irc_bot.py
+++ b/util/irc_bot.py
@@ -10,6 +10,7 @@ import irc.strings
 from irc.client import ip_numstr_to_quad, ip_quad_to_numstr
 import irc.client
 import jaraco.logging
+import time
 
 class IRCBot(object):
   def __init__(self, channel, nickname, server, port=6667):


### PR DESCRIPTION
Tested; before:

```
01:50 -!- benchmark [~benchmark@shoeshine.cc.gt.atl.ga.us] has joined #mlpack
01:50 -benchmark:#mlpack- ALLKFN (-k 3 --r_tree) | covtype >1000 <=> >1000 | corel-histogram 137.435966 <=> 142.784782 |
01:50 -benchmark:#mlpack- ALLKFN (-k 3 --cover_tree) | covtype failure <=> failure | corel-histogram failure <=> failure |
01:50 -benchmark:#mlpack- ALLKFN (-k 3) | covtype 972.579228 <=> 975.949520 | corel-histogram 85.322623 <=> 88.706395 |
01:50 -benchmark:#mlpack- ALLKFN (-k 3 --single --cover_tree) | covtype failure <=> failure | corel-histogram failure <=> failure |
01:50 -benchmark:#mlpack- ALLKFN (-k 3 --single --r_tree) | covtype >1000 <=> >1000 | corel-histogram 488.523422 <=> 489.963464 |
01:50 -!- benchmark [~benchmark@shoeshine.cc.gt.atl.ga.us] has quit [Excess Flood]
```

After:

```
11:59 -!- irc-bot-test [~irc-bot-t@38.33.7.109.rev.sfr.net] has joined #mlpack
11:59 -irc-bot-test:#mlpack- test message #1
11:59 -irc-bot-test:#mlpack- test message #2
11:59 -irc-bot-test:#mlpack- test message #3
11:59 -irc-bot-test:#mlpack- test message #4
11:59 -irc-bot-test:#mlpack- test message #5
11:59 -irc-bot-test:#mlpack- test message #6
11:59 -irc-bot-test:#mlpack- test message #7
11:59 -irc-bot-test:#mlpack- test message #8
11:59 -irc-bot-test:#mlpack- test message #9
11:59 -irc-bot-test:#mlpack- test message #10
11:59 -!- irc-bot-test [~irc-bot-t@38.33.7.109.rev.sfr.net] has quit [Client Quit]
```

I've submitted this as a PR in case there is a better way to do this that I didn't notice.